### PR TITLE
Clear the network log on browser reload

### DIFF
--- a/src/components/Toolbar.css
+++ b/src/components/Toolbar.css
@@ -4,6 +4,7 @@
   border-bottom: var(--divider-border);
   flex: none;
   padding: 0 2px;
+  user-select: none;
 }
 
 .toolbar-shadow {
@@ -29,6 +30,14 @@
   height: 26px;
   border: none;
   white-space: pre;
+}
+
+.toolbar-item.checkbox {
+  padding: 0 5px 0 2px;
+}
+
+.toolbar-item.checkbox:hover {
+  color: #333;
 }
 
 :focus {

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -1,19 +1,36 @@
 // Copyright (c) 2019 SafetyCulture Pty Ltd. All Rights Reserved.
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { setPreserveLog } from '../state/network';
 import './Toolbar.css';
 
 
 
 class Toolbar extends Component {
   render() {
+    const { preserveLog } = this.props;
     return (
       <div className="toolbar">
         <div className="toolbar-shadow">
+          <span className="toolbar-item checkbox">
+            <input
+              type="checkbox"
+              id="ui-checkbox-preserve-log"
+              checked={preserveLog}
+              onChange={this._onPreserveLogChanged}
+            />
+            <label for="ui-checkbox-preserve-log">Preserve log</label>
+          </span>
           {/* <ToolbarButton onClick={() => {}} /> */}
         </div>
       </div>
     );
+  }
+
+  _onPreserveLogChanged = (e) => {
+    const { setPreserveLog } = this.props;
+    setPreserveLog(e.target.checked);
   }
 }
 
@@ -27,4 +44,6 @@ class Toolbar extends Component {
 //   }
 // }
 
-export default Toolbar;
+const mapStateToProps = state => ({ preserveLog: state.network.preserveLog });
+const mapDispatchToProps = { setPreserveLog };
+export default connect(mapStateToProps, mapDispatchToProps)(Toolbar);

--- a/src/state/network.js
+++ b/src/state/network.js
@@ -3,6 +3,7 @@ import { createSlice } from "redux-starter-kit";
 const networkSlice = createSlice({
     slice: 'network',
     initialState: {
+        preserveLog: false,
         selectedIdx: null,
         selectedEntry: null,
         log: [],
@@ -23,11 +24,24 @@ const networkSlice = createSlice({
                 state.selectedIdx = idx;
                 state.selectedEntry = entry;
             }
-        }
+        },
+        clearLog(state, action) {
+            const { payload: { force } = {} } = action;
+            if (state.preserveLog && !force) {
+                return;
+            }
+            state.selectedIdx = null;
+            state.selectedEntry = null;
+            state.log = [];
+        },
+        setPreserveLog(state, action) {
+            const { payload } = action;
+            state.preserveLog = payload;
+        },
     }
 });
 
 const { actions, reducer } = networkSlice;
-export const { networkLog, selectLogEntry } = actions;
+export const { networkLog, selectLogEntry, clearLog, setPreserveLog } = actions;
 
 export default reducer


### PR DESCRIPTION
Fixes #5 

Also adds a `Preserve Log` checkbox that will maintain the log on reload if `checked == true`