### PR TITLE
Enable clipboard in React Json view

### DIFF
--- a/src/components/NetworkDetails.js
+++ b/src/components/NetworkDetails.js
@@ -21,7 +21,7 @@ class NetworkDetails extends Component {
       if (request) src.request = request;
       if (response) src.response = response;
       if (error) src.error = error;
-      return <ReactJson name="grpc" enableClipboard={false} src={src} />
+      return <ReactJson name="grpc" enableClipboard={true} src={src} />
     }
   }
 }


### PR DESCRIPTION
This PR enables clipboard when for network details, fixes this issue
https://github.com/SafetyCulture/grpc-web-devtools/issues/49 

<img width="633" alt="Screen Shot 2019-10-19 at 11 29 08 pm" src="https://user-images.githubusercontent.com/2775497/67144936-58e08180-f2c8-11e9-85ff-34b868184810.png">
<img width="650" alt="Screen Shot 2019-10-19 at 11 29 31 pm" src="https://user-images.githubusercontent.com/2775497/67144937-58e08180-f2c8-11e9-8c8e-c6fbd76c2d37.png">
