### PR TITLE
Update connect-web-interceptor.js for v0.8.0 and later

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ grpc-web-devtools now also supports [connect-web](https://github.com/bufbuild/co
 
 ```ts
 // __CONNECT_WEB_DEVTOOLS__ is loaded in as a script, so it is not guaranteed to be loaded before your code.
-const interceptors: Interceptor[] = window.__CONNECT_WEB_DEVTOOLS__ !== "undefined" ?
+const interceptors: Interceptor[] = window.__CONNECT_WEB_DEVTOOLS__ !== undefined ?
   [window.__CONNECT_WEB_DEVTOOLS__]
   : [];
 // To get around the fact that __CONNECT_WEB_DEVTOOLS__ might not be loaded, we can listen for a custom event,
 // and then push the interceptor to our array once loaded.
 window.addEventListener("connect-web-dev-tools-ready", () => {
-  if (typeof window.__CONNECT_WEB_DEVTOOLS__ !== "undefined") {
+  if (window.__CONNECT_WEB_DEVTOOLS__ !== undefined) {
     interceptors.push(window.__CONNECT_WEB_DEVTOOLS__);
   }
 });

--- a/public/connect-web-interceptor.js
+++ b/public/connect-web-interceptor.js
@@ -1,53 +1,110 @@
+const MethodKind = {
+  Unary: 0,
+  ServerStreaming: 1,
+};
+
 // This interceptor will be passed every request and response. We will take that request and response
 // and post a message to the window. This will allow us to access this message in the content script. This
 // is all to make the manifest v3 happy.
-const interceptor =
-  (next) =>
-    async (req) => {
-      return await next(req).then((resp) => {
-        if (!resp.stream) {
-          window.postMessage({
-            type: "__GRPCWEB_DEVTOOLS__",
-            methodType: "unary",
-            method: req.method.name,
-            request: req.message.toJson(),
-            response: resp.message.toJson(),
-          }, "*")
-          return resp;
-        } else {
-          return {
-            ...resp,
-            async read() {
-              const streamResp = await resp.read();
-              // "value" could be undefined when "done" is true
-              if (streamResp.value) {
-                window.postMessage({
-                  type: "__GRPCWEB_DEVTOOLS__",
-                  methodType: "server_streaming",
-                  method: req.method.name,
-                  request: req.message.toJson(),
-                  response: streamResp.value.toJson(),
-                }, "*");
-              }
-              return streamResp;
-            }
-          }
-        }
-      }).catch((e) => {
-        window.postMessage({
-          type: "__GRPCWEB_DEVTOOLS__",
-          methodType: req.stream ? "server_streaming" : "unary",
-          method: req.method.name,
-          request: req.message.toJson(),
-          response: undefined,
-          error: {
-            message: e.message,
-            code: e.code,
-          }
-        }, "*")
+const interceptor = (next) => async (req) => {
+  switch (req.method.kind) {
+    case MethodKind.Unary:
+      try {
+        assert(!req.stream);
+        const resp = await next(req);
+        assert(!resp.stream);
+        post(req.service, req.method, req.message, resp.message);
+        return resp;
+      } catch (e) {
+        post(req.service, req.method, req.message, undefined, e);
         throw e;
-      });
+      }
+    case MethodKind.ServerStreaming:
+      try {
+        assert(req.stream);
+        let reqMessage;
+        const resp = await next({
+          ...req,
+          message: wrap(
+            req.message, message => {
+              reqMessage = message;
+            },
+            reason => {
+              post(req.service, req.method, reqMessage, undefined, reason);
+            })
+        });
+        assert(resp.stream);
+        return {
+          ...resp,
+          message: wrap(
+            resp.message,
+            message => {
+              post(req.service, req.method, reqMessage, message);
+            }, reason => {
+              post(req.service, req.method, reqMessage, undefined, reason);
+            })
+        };
+      } catch (e) {
+        post(req.service, req.method, undefined, undefined, e);
+        throw e;
+      }
+    default:
+      assert(false);
+  }
+};
+
+function post(service, method, requestMessage, responseMessage, error = undefined) {
+  const m = {
+    type: "__GRPCWEB_DEVTOOLS__",
+    methodType: method.kind === MethodKind.Unary ? "unary" : "server_streaming",
+    method: service.typeName + "/" + method.name,
+    request: undefined,
+    response: undefined,
+  };
+  if (requestMessage) {
+    try {
+      m.request = requestMessage.toJson({emitDefaultValues: true});
+    } catch (e) {
+      // serializing google.protobuf.Any requires a type registry
+    }
+  }
+  if (responseMessage) {
+    try {
+      m.response = responseMessage.toJson({emitDefaultValues: true});
+    } catch (e) {
+      // serializing google.protobuf.Any requires a type registry
+    }
+  }
+  if (error) {
+    m.error = {
+      message: error.message,
+      code: error.code,
     };
+  }
+  window.postMessage(m, "*");
+}
+
+function wrap(it, onMessage, onError) {
+  async function* generator() {
+    try {
+      for await (const m of it) {
+        onMessage(m);
+        yield m;
+      }
+    } catch (e) {
+      onError(e);
+      throw e;
+    }
+  }
+
+  return generator();
+}
+
+function assert(condition) {
+  if (!condition) {
+    throw new Error("assertion failed");
+  }
+}
 
 window.__CONNECT_WEB_DEVTOOLS__ = interceptor;
 


### PR DESCRIPTION
## Summary

Update the connect-web-interceptor.js to be compatible with @buildbuild/connect-web >= v0.8.0 for server-streaming RPCs.


<!-- Short summary of what the PR does -->

## Problem description


Release [v0.8.0](https://github.com/bufbuild/connect-es/releases/tag/v0.8.0) of @buildbuild/connect-web made a breaking change to interceptors. Unary RPCs are still compatible, but server-streaming RPCs no longer show up in the grpc-web-devtools.

With this change, server-streaming RPCs show up in the grpc-web-devtools again. 

Other changes:
- Show the full RPC name in the devtools - for example `connectrpc.eliza.v1.ElizaService/Say` instead of just `Say`.
- Use the JSON option `emitDefaultValues` for a more human-friendly representation.
- Swallow JSON serialization errors that may occur when a `google.protobuf.Any` is present in the schema.
- Fix the connect-web integration instructions, superseding https://github.com/SafetyCulture/grpc-web-devtools/pull/160 and https://github.com/SafetyCulture/grpc-web-devtools/pull/155

Server-streaming and unary RPCs tested with Chrome and Firefox:

<img width="1109" alt="a" src="https://github.com/SafetyCulture/grpc-web-devtools/assets/4289451/9fb95bcb-dc7b-46f5-9bd6-cb711401ffc2">

Errors in unary and server-streaming RPCs tested with Chrome and Firefox:

<img width="1110" alt="b" src="https://github.com/SafetyCulture/grpc-web-devtools/assets/4289451/84d5d190-b237-4091-851c-3494d107dd4e">

<img width="1115" alt="c" src="https://github.com/SafetyCulture/grpc-web-devtools/assets/4289451/6b21c2da-489c-4332-bd41-9f7116d9b746">


<!-- Description of the problem being solved -->

## Pros/cons of approach implemented

The behavior for users of versions < 0.8.0 changes with this PR - they will no longer see server-streaming RPCs in the grpc-web-devtools. Since less than 2% of the downloads for of @bufbuild/connect-web are for older versions, this 

It would ideal to support type registries for `google.protobuf.Any`, but swallowing seems better than crashing.

## Checklist

<!-- Does it make sense for this PR to be of this size? If the PR is large, consider breaking it down into smaller incremental PRs. To check the box, put an `x` in the box -->

- [x] Is this PR a reasonable size?

<!-- Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally. -->

---

**Code Review Guidelines** for Reviewers

- Try to review in a timely manner. Opinions/nitpicks should not be blockers. Pair on a call for non-trivial feedback.
- Overall design and approach should follow established patterns. Don't try to make the PR perfect.
- Try to identify edge cases, race conditions, over-engineering, lack of test coverage and complexity.
- If you don't feel qualified to review the code, pass it on to someone who is.
