### PR TITLE
IRES-508: Fix streaming interceptor

### DIFF
--- a/public/connect-web-interceptor.js
+++ b/public/connect-web-interceptor.js
@@ -1,57 +1,67 @@
-// This interceptor will be passed every request and response. We will take that request and response
-// and post a message to the window. This will allow us to access this message in the content script. This
-// is all to make the manifest v3 happy.
-const interceptor =
-  (next) =>
-    async (req) => {
-      return await next(req).then((resp) => {
-        if (!resp.stream) {
-          window.postMessage({
-            type: "__GRPCWEB_DEVTOOLS__",
-            methodType: "unary",
-            method: req.method.name,
-            request: req.message.toJson(),
-            response: resp.message.toJson(),
-          }, "*")
-          return resp;
-        } else {
-          return {
-            ...resp,
-            async read() {
-              const streamResp = await resp.read();
-              // "value" could be undefined when "done" is true
-              if (streamResp.value) {
-                window.postMessage({
-                  type: "__GRPCWEB_DEVTOOLS__",
-                  methodType: "server_streaming",
-                  method: req.method.name,
-                  request: req.message.toJson(),
-                  response: streamResp.value.toJson(),
-                }, "*");
-              }
-              return streamResp;
-            }
-          }
-        }
-      }).catch((e) => {
-        window.postMessage({
-          type: "__GRPCWEB_DEVTOOLS__",
-          methodType: req.stream ? "server_streaming" : "unary",
-          method: req.method.name,
-          request: req.message.toJson(),
-          response: undefined,
-          error: {
-            message: e.message,
-            code: e.code,
-          }
-        }, "*")
-        throw e;
-      });
-    };
+/**
+ * Reads the message from the stream and posts it to the window.
+ * This is a generator function that will be passed to the response stream.
+ */
+async function* readMessage(req, stream) {
+  for await (const m of stream) {
+    if (m) {
+      const resp = m.toJson?.();
+      window.postMessage({
+        type: "__GRPCWEB_DEVTOOLS__",
+        methodType: "server_streaming",
+        method: req.method.name,
+        request: req.message.toJson?.(),
+        response: resp,
+      }, "*");
+    }
+    yield m;
+  }
+}
+
+/**
+ * This interceptor will be passed every request and response. We will take that request and response
+ * and post a message to the window. This will allow us to access this message in the content script. This
+ * is all to make the manifest v3 happy.
+ */
+const interceptor = (next) => async (req) => {
+  try {
+    const resp = await next(req);
+    if (!resp.stream) {
+      window.postMessage({
+        type: "__GRPCWEB_DEVTOOLS__",
+        methodType: "unary",
+        method: req.method.name,
+        request: req.message.toJson(),
+        response: resp.message.toJson(),
+      }, "*")
+      return resp;
+    } else {
+      return {
+        ...resp,
+        message: readMessage(req, resp.message),
+      }
+    }
+  } catch (e) {
+    window.postMessage({
+      type: "__GRPCWEB_DEVTOOLS__",
+      methodType: req.stream ? "server_streaming" : "unary",
+      method: req.method.name,
+      request: req.message.toJson(),
+      response: undefined,
+      error: {
+        message: e.message,
+        code: e.code,
+      }
+    }, "*")
+    throw e;
+  }
+};
 
 window.__CONNECT_WEB_DEVTOOLS__ = interceptor;
 
-// Since we are loading inject.js as a script, the order at which it is loaded is not guaranteed.
-// So we will publish a custom event that can be used, to be used to assign the interceptor.
+/**
+ * Since we are loading inject.js as a script, the order at which it is loaded is not guaranteed.
+ * So we will publish a custom event that can be used, to be used to assign the interceptor.
+ */
 const readyEvent = new CustomEvent("connect-web-dev-tools-ready");
 window.dispatchEvent(readyEvent);

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "gRPC-Web Developer Tools",
-  "version": "1.2.1",
+  "version": "1.4.0",
   "manifest_version": 2,
   "description": "gRPC-Web Developer Tools for debugging application's gRPC-Web network requests.",
   "icons": {


### PR DESCRIPTION
## Changes
1. Updates the `connect-web-interceptor` script to handle streaming requests.
2. Switch to a try catch to match the await needed by the message generator.

Connect has documentation on how to properly setup a streaming interceptor. This implements that interceptor and ensures it is working. It looks like streaming was not previously working at all.
https://connectrpc.com/docs/web/interceptors/

### 
<img width="1789" alt="Screenshot 2023-11-06 at 1 18 02 pm" src="https://github.com/SafetyCulture/grpc-web-devtools/assets/59549216/535632d7-2f86-41f0-9108-448ea80e160f">

### Previously

https://github.com/SafetyCulture/grpc-web-devtools/assets/59549216/7cd1ef3d-d16e-414b-8079-687b37a11629

