### PR TITLE
Emit default values when converting message to JSON for display

### DIFF
--- a/public/connect-web-interceptor.js
+++ b/public/connect-web-interceptor.js
@@ -5,12 +5,12 @@
 async function* readMessage(req, stream) {
   for await (const m of stream) {
     if (m) {
-      const resp = m.toJson?.();
+      const resp = m.toJson?.({emitDefaultValues: true});
       window.postMessage({
         type: "__GRPCWEB_DEVTOOLS__",
         methodType: "server_streaming",
         method: req.method.name,
-        request: req.message.toJson?.(),
+        request: req.message.toJson?.({emitDefaultValues: true}),
         response: resp,
       }, "*");
     }
@@ -31,8 +31,8 @@ const interceptor = (next) => async (req) => {
         type: "__GRPCWEB_DEVTOOLS__",
         methodType: "unary",
         method: req.method.name,
-        request: req.message.toJson(),
-        response: resp.message.toJson(),
+        request: req.message.toJson({emitDefaultValues: true}),
+        response: resp.message.toJson({emitDefaultValues: true}),
       }, "*")
       return resp;
     } else {
@@ -46,7 +46,7 @@ const interceptor = (next) => async (req) => {
       type: "__GRPCWEB_DEVTOOLS__",
       methodType: req.stream ? "server_streaming" : "unary",
       method: req.method.name,
-      request: req.message.toJson(),
+      request: req.message.toJson({emitDefaultValues: true}),
       response: undefined,
       error: {
         message: e.message,


### PR DESCRIPTION
<!-- Expectations for PRs: https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards -->

## Summary

This change enables visibility of default values in the request and response objects.
E.g empty strings and false booleans.
what would have show as this before
```
{
  "foo": "bar"
}
```

Looks like this after
```
{
  "foo": "bar",
  "baz": "",
  importantBoolean: false
}
```

## Problem description

Not displaying defalt values is misleading and is against the idioms of GRPC.

## Pros/cons of approach implemented

Pros: It's simple and uses existing functionality.
Cons: It's non-configurable.

## Checklist

<!-- Does it make sense for this PR to be of this size? If the PR is large, consider breaking it down into smaller incremental PRs. To check the box, put an `x` in the box -->

- [x] Is this PR a reasonable size?

<!-- Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally. -->

---

**Code Review Guidelines** for Reviewers

- Try to review in a timely manner. Opinions/nitpicks should not be blockers. Pair on a call for non-trivial feedback.
- Overall design and approach should follow established patterns. Don't try to make the PR perfect.
- Try to identify edge cases, race conditions, over-engineering, lack of test coverage and complexity.
- If you don't feel qualified to review the code, pass it on to someone who is.
