### PR TITLE
[WB-1999] Fix stream error catching

### DIFF
--- a/public/connect-web-interceptor.js
+++ b/public/connect-web-interceptor.js
@@ -46,7 +46,7 @@ const interceptor = (next) => async (req) => {
       type: "__GRPCWEB_DEVTOOLS__",
       methodType: req.stream ? "server_streaming" : "unary",
       method: req.method.name,
-      request: req.message.toJson(),
+      request: req.message.toJson?.(),
       response: undefined,
       error: {
         message: e.message,


### PR DESCRIPTION
<!-- Expectations for PRs: https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards -->

## Summary
When the stream request got rejected, for example it's cancelled by user, the `req.message` does not have the `toJson` method, caused one unrelated exception went to the error handler of API call, eventually we cannot consume the original error(like the AbortError) correctly. 

This PR marked the `toJson` as optional to skip calling a undefined method.

## Pros/cons of approach implemented

## Checklist

<!-- Does it make sense for this PR to be of this size? If the PR is large, consider breaking it down into smaller incremental PRs. To check the box, put an `x` in the box -->

- [ ] Is this PR a reasonable size?

<!-- If this PR is part of a broader set of changes, please provide a deployment sequence that includes all relevant PRs, so that changes can be reverted in the right order if a rollback were required (e.g. as part of an incident mitigation). To check the box, put an `x` in the box -->

- [ ] List deployment sequence with all relevant PRs.
  - ...

<!-- Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally. -->

---

**Code Review Guidelines** for Reviewers

- Try to review in a timely manner. Opinions/nitpicks should not be blockers. Pair on a call for non-trivial feedback.
- Overall design and approach should follow established patterns. Don't try to make the PR perfect.
- Try to identify edge cases, race conditions, over-engineering, lack of test coverage and complexity.
- If you don't feel qualified to review the code, pass it on to someone who is.
