### PR TITLE
fix(connect-web-interceptor): connect v2 compatibility

### DIFF
--- a/public/connect-web-interceptor.js
+++ b/public/connect-web-interceptor.js
@@ -1,16 +1,22 @@
 /**
+ * In Connect v2, the `toJson` method is no longer available, and we can directly use the message itself.
+ */
+const toJson = (obj) => {
+  return obj.toJson?.() || obj;
+}
+/**
  * Reads the message from the stream and posts it to the window.
  * This is a generator function that will be passed to the response stream.
  */
 async function* readMessage(req, stream) {
   for await (const m of stream) {
     if (m) {
-      const resp = m.toJson?.();
+      const resp = toJson(m);
       window.postMessage({
         type: "__GRPCWEB_DEVTOOLS__",
         methodType: "server_streaming",
         method: req.method.name,
-        request: req.message.toJson?.(),
+        request: toJson(req.message),
         response: resp,
       }, "*");
     }
@@ -31,8 +37,8 @@ const interceptor = (next) => async (req) => {
         type: "__GRPCWEB_DEVTOOLS__",
         methodType: "unary",
         method: req.method.name,
-        request: req.message.toJson(),
-        response: resp.message.toJson(),
+        request: toJson(req.message),
+        response: toJson(resp.message),
       }, "*")
       return resp;
     } else {
@@ -46,7 +52,7 @@ const interceptor = (next) => async (req) => {
       type: "__GRPCWEB_DEVTOOLS__",
       methodType: req.stream ? "server_streaming" : "unary",
       method: req.method.name,
-      request: req.message.toJson?.(),
+      request: toJson(req.message),
       response: undefined,
       error: {
         message: e.message,


### PR DESCRIPTION
<!-- Expectations for PRs: https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards -->

## Summary

In [Connect v2](https://github.com/connectrpc/connect-es/blob/main/MIGRATING.md#message-class-methods), messages are plain JSON objects so there are no method classes on them anymore. This PR adds JSON serialization in both ways.

## Problem description

Using Connect v2 with grpc-web-devtools causes this error :
```
ConnectError: [unknown] req.message.toJson is not a function
```

## Checklist

<!-- Does it make sense for this PR to be of this size? If the PR is large, consider breaking it down into smaller incremental PRs. To check the box, put an `x` in the box -->

- [x] Is this PR a reasonable size?

<!-- Does this PR cause breaking changes? If so, it is your responsibility to check that other repositories are not affected. If they are, you must plan a deployment sequence (see above) to ensure any impact is addressed. Once you have done this, put an `x` in the box -->

- [x] For breaking changes: I have confirmed that other repos are not affected, or I have planned a deployment sequence to address any impact.

<!-- Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally. -->

---

**Code Review Guidelines** for Reviewers

- Try to review in a timely manner. Opinions/nitpicks should not be blockers. Pair on a call for non-trivial feedback.
- Overall design and approach should follow established patterns. Don't try to make the PR perfect.
- Try to identify edge cases, race conditions, over-engineering, lack of test coverage and complexity.
- If you don't feel qualified to review the code, pass it on to someone who is.
