### PR TITLE
Fix link to Chrome Web Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Now supports dark mode.
 ### Chrome
 
 Via
-the [Chrome Web Store](https://chrome.google.com/webstore/detail/grpc-web-developer-tools/kanmilmfkjnoladbbamlclhccicldjaj) (
+the [Chrome Web Store](https://chromewebstore.google.com/detail/grpc-web-developer-tools/cacoibopgjlodngfokahhkphgcohakai) (
 recommended)
 
 or


### PR DESCRIPTION
The current link in the readme (https://chrome.google.com/webstore/detail/grpc-web-developer-tools/kanmilmfkjnoladbbamlclhccicldjaj) does not point to an extension:
![Screenshot 2025-02-25 at 1 49 26 PM](https://github.com/user-attachments/assets/22880da3-f9f6-4026-b967-b8495b446500)

I think this is the correct link given the screenshots are identical to what is in the readme: https://chromewebstore.google.com/detail/grpc-web-developer-tools/cacoibopgjlodngfokahhkphgcohakai